### PR TITLE
fix: compile error

### DIFF
--- a/containers/Dialogs/CreateThreadDialog.tsx
+++ b/containers/Dialogs/CreateThreadDialog.tsx
@@ -160,7 +160,10 @@ const CreateThreadDialog = () => {
           <Button
             onClick={form.handleSubmit(onSubmit, (e) => {
               toast({
-                title: e?.[Object.keys(e)?.[0]]?.message ?? "表單發生錯誤",
+                title:
+                  (e as Record<string, { message?: string }>)?.[
+                    Object.keys(e)?.[0]
+                  ]?.message ?? "表單發生錯誤",
                 variant: "error",
               });
             })}


### PR DESCRIPTION
This pull request makes a minor update to the error handling in the `CreateThreadDialog` component to improve TypeScript type safety when displaying form validation errors.

* Improved type safety for error message extraction in the `onClick` handler by casting the error object to a more specific type.