### PR TITLE
fix: stopPropagation for thread card

### DIFF
--- a/components/thread/ThreadCard.tsx
+++ b/components/thread/ThreadCard.tsx
@@ -19,7 +19,8 @@ import { cn, formatDate } from "@/lib/utils";
 import userStore from "@/store/userStore";
 import { isEmpty } from "lodash-es";
 import { Heart, Trash2 } from "lucide-react";
-import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
+import { useParams } from "next/navigation";
 import { useState } from "react";
 import { mutate } from "swr";
 
@@ -46,7 +47,6 @@ interface ThreadCardProps {
 
 const ThreadCard = ({ thread, courseId }: ThreadCardProps) => {
   const params = useParams();
-  const router = useRouter();
   const { toast } = useToast();
   const { userData } = userStore();
   const isLoggedIn = !isEmpty(userData);
@@ -99,9 +99,9 @@ const ThreadCard = ({ thread, courseId }: ThreadCardProps) => {
   if (deleted) return null;
 
   return (
+    <Link href={href}>
     <Card
-      className="hover:bg-muted transition-colors cursor-pointer"
-      onClick={() => router.push(href)}
+      className="hover:bg-muted transition-colors"
     >
       <div className="flex items-start justify-between gap-2">
         <div className="flex items-center gap-2 min-w-0">
@@ -126,7 +126,7 @@ const ThreadCard = ({ thread, courseId }: ThreadCardProps) => {
             </Badge>
           )}
           {thread.is_owner && (
-            <div onClick={(e) => e.stopPropagation()}>
+            <div onClick={(e) => { e.stopPropagation(); e.preventDefault(); }}>
               <AlertDialog>
                 <AlertDialogTrigger asChild>
                   <Button
@@ -174,10 +174,7 @@ const ThreadCard = ({ thread, courseId }: ThreadCardProps) => {
               "gap-1.5 h-8 px-2",
               liked && "text-red-500 hover:text-red-600",
             )}
-            onClick={(e) => {
-              e.stopPropagation();
-              handleLike(e);
-            }}
+            onClick={handleLike}
             disabled={isLiking}
           >
             <Heart className={cn("h-4 w-4", liked && "fill-current")} />
@@ -192,6 +189,7 @@ const ThreadCard = ({ thread, courseId }: ThreadCardProps) => {
         )}
       </div>
     </Card>
+    </Link>
   );
 };
 

--- a/components/thread/ThreadCard.tsx
+++ b/components/thread/ThreadCard.tsx
@@ -19,8 +19,7 @@ import { cn, formatDate } from "@/lib/utils";
 import userStore from "@/store/userStore";
 import { isEmpty } from "lodash-es";
 import { Heart, Trash2 } from "lucide-react";
-import Link from "next/link";
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { useState } from "react";
 import { mutate } from "swr";
 
@@ -47,6 +46,7 @@ interface ThreadCardProps {
 
 const ThreadCard = ({ thread, courseId }: ThreadCardProps) => {
   const params = useParams();
+  const router = useRouter();
   const { toast } = useToast();
   const { userData } = userStore();
   const isLoggedIn = !isEmpty(userData);
@@ -99,96 +99,99 @@ const ThreadCard = ({ thread, courseId }: ThreadCardProps) => {
   if (deleted) return null;
 
   return (
-    <Link href={href}>
-      <Card className="hover:bg-muted transition-colors cursor-pointer">
-        <div className="flex items-start justify-between gap-2">
-          <div className="flex items-center gap-2 min-w-0">
-            <Avatar className="h-8 w-8 shrink-0">
-              <AvatarFallback className="text-xs">
-                {displayName.slice(0, 1)}
-              </AvatarFallback>
-            </Avatar>
-            <div className="min-w-0">
-              <p className="text-sm font-medium leading-none">
-                {displayName}
-              </p>
-              <p className="text-xs text-muted-foreground mt-1">
-                {formattedDate}
-              </p>
+    <Card
+      className="hover:bg-muted transition-colors cursor-pointer"
+      onClick={() => router.push(href)}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex items-center gap-2 min-w-0">
+          <Avatar className="h-8 w-8 shrink-0">
+            <AvatarFallback className="text-xs">
+              {displayName.slice(0, 1)}
+            </AvatarFallback>
+          </Avatar>
+          <div className="min-w-0">
+            <p className="text-sm font-medium leading-none">
+              {displayName}
+            </p>
+            <p className="text-xs text-muted-foreground mt-1">
+              {formattedDate}
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-1 shrink-0">
+          {thread.is_anonymous && (
+            <Badge variant="secondary" className="text-xs">
+              匿名
+            </Badge>
+          )}
+          {thread.is_owner && (
+            <div onClick={(e) => e.stopPropagation()}>
+              <AlertDialog>
+                <AlertDialogTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    aria-label="刪除討論"
+                    className="h-7 w-7 text-destructive hover:text-destructive"
+                    disabled={isDeleting}
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </Button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>確定要刪除這篇討論嗎？</AlertDialogTitle>
+                    <AlertDialogDescription>此操作無法復原。</AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>取消</AlertDialogCancel>
+                    <AlertDialogAction onClick={handleDelete} disabled={isDeleting}>
+                      刪除
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
             </div>
-          </div>
-          <div className="flex items-center gap-1 shrink-0">
-            {thread.is_anonymous && (
-              <Badge variant="secondary" className="text-xs">
-                匿名
-              </Badge>
-            )}
-            {thread.is_owner && (
-              <div onClick={(e) => e.preventDefault()}>
-                <AlertDialog>
-                  <AlertDialogTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      aria-label="刪除討論"
-                      className="h-7 w-7 text-destructive hover:text-destructive"
-                      disabled={isDeleting}
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      <Trash2 className="h-3.5 w-3.5" />
-                    </Button>
-                  </AlertDialogTrigger>
-                  <AlertDialogContent>
-                    <AlertDialogHeader>
-                      <AlertDialogTitle>確定要刪除這篇討論嗎？</AlertDialogTitle>
-                      <AlertDialogDescription>此操作無法復原。</AlertDialogDescription>
-                    </AlertDialogHeader>
-                    <AlertDialogFooter>
-                      <AlertDialogCancel>取消</AlertDialogCancel>
-                      <AlertDialogAction onClick={handleDelete} disabled={isDeleting}>
-                        刪除
-                      </AlertDialogAction>
-                    </AlertDialogFooter>
-                  </AlertDialogContent>
-                </AlertDialog>
-              </div>
-            )}
-          </div>
-        </div>
-        <div>
-          <h3 className="font-semibold text-base leading-tight">
-            {thread.title}
-          </h3>
-          <p className="text-sm text-muted-foreground line-clamp-2 whitespace-pre-wrap mt-1">
-            {thread.content}
-          </p>
-        </div>
-        <div className="flex items-center">
-          {isLoggedIn && (
-            <Button
-              variant="ghost"
-              size="sm"
-              aria-label={liked ? "取消喜歡" : "喜歡"}
-              className={cn(
-                "gap-1.5 h-8 px-2",
-                liked && "text-red-500 hover:text-red-600",
-              )}
-              onClick={handleLike}
-              disabled={isLiking}
-            >
-              <Heart className={cn("h-4 w-4", liked && "fill-current")} />
-              <span className="text-xs">{likeCount}</span>
-            </Button>
-          )}
-          {!isLoggedIn && (
-            <span className="flex items-center gap-1 h-8 px-2 text-xs text-muted-foreground">
-              <Heart className="h-4 w-4" />
-              {likeCount}
-            </span>
           )}
         </div>
-      </Card>
-    </Link>
+      </div>
+      <div>
+        <h3 className="font-semibold text-base leading-tight">
+          {thread.title}
+        </h3>
+        <p className="text-sm text-muted-foreground line-clamp-2 whitespace-pre-wrap mt-1">
+          {thread.content}
+        </p>
+      </div>
+      <div className="flex items-center">
+        {isLoggedIn && (
+          <Button
+            variant="ghost"
+            size="sm"
+            aria-label={liked ? "取消喜歡" : "喜歡"}
+            className={cn(
+              "gap-1.5 h-8 px-2",
+              liked && "text-red-500 hover:text-red-600",
+            )}
+            onClick={(e) => {
+              e.stopPropagation();
+              handleLike(e);
+            }}
+            disabled={isLiking}
+          >
+            <Heart className={cn("h-4 w-4", liked && "fill-current")} />
+            <span className="text-xs">{likeCount}</span>
+          </Button>
+        )}
+        {!isLoggedIn && (
+          <span className="flex items-center gap-1 h-8 px-2 text-xs text-muted-foreground">
+            <Heart className="h-4 w-4" />
+            {likeCount}
+          </span>
+        )}
+      </div>
+    </Card>
   );
 };
 


### PR DESCRIPTION
This pull request refactors the `ThreadCard` component to improve navigation and event handling. The main change is replacing the `Link` component with a `Card` that uses `router.push` for navigation, allowing for more flexible event management and preventing unwanted navigation when interacting with child elements like the delete and like buttons. Event propagation is now carefully managed to ensure button clicks do not trigger navigation.

**Navigation and Event Handling Improvements:**

* Replaced the `Link` wrapper with a `Card` component that navigates using `router.push(href)` in the `onClick` handler, providing more control over navigation and event handling.
* Updated event handling for the delete and like buttons to use `e.stopPropagation()`, preventing their clicks from triggering the card's navigation. [[1]](diffhunk://#diff-13af614b19bfa728fd8e19cfc8cbeecb1e09774a47dccff4fe9de57f54c8ff82L127-R129) [[2]](diffhunk://#diff-13af614b19bfa728fd8e19cfc8cbeecb1e09774a47dccff4fe9de57f54c8ff82L176-R180)
* Removed redundant or misplaced `onClick` handlers and ensured all relevant button clicks properly stop event propagation.

**Imports and Hook Usage:**

* Updated imports to use `useRouter` from `next/navigation` and removed the unused `Link` import. [[1]](diffhunk://#diff-13af614b19bfa728fd8e19cfc8cbeecb1e09774a47dccff4fe9de57f54c8ff82L22-R22) [[2]](diffhunk://#diff-13af614b19bfa728fd8e19cfc8cbeecb1e09774a47dccff4fe9de57f54c8ff82R49)

**Code Cleanup:**

* Removed the unnecessary closing `</Link>` tag after moving navigation to the `Card` component.