### PR TITLE
Add community rules for thread creation and copyright guidelines

### DIFF
--- a/containers/Dialogs/CreateThreadDialog.tsx
+++ b/containers/Dialogs/CreateThreadDialog.tsx
@@ -83,7 +83,7 @@ function GuidelinesSheet() {
         <Separator />
         <ul className="flex flex-col divide-y px-6">
           {GUIDELINES.map((g, i) => (
-            <li key={i} className="py-4">
+            <li key={g.title} className="py-4">
               <div className="mb-1 flex items-center gap-2">
                 <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-destructive/10 text-xs font-bold text-destructive">
                   {i + 1}
@@ -225,7 +225,7 @@ const CreateThreadDialog = () => {
             />
           </form>
         </Form>
-        <div className="flex items-start gap-2 py-1">
+        <div className="flex flex-row items-start space-x-3 space-y-0 py-2">
           <Checkbox
             id="agree-guidelines"
             checked={agreed}

--- a/containers/Dialogs/CreateThreadDialog.tsx
+++ b/containers/Dialogs/CreateThreadDialog.tsx
@@ -54,6 +54,10 @@ const GUIDELINES = [
     title: "禁止侵犯隱私",
     desc: "不得未經同意公開他人個人資訊，例如學號、姓名、聯絡方式等。",
   },
+  {
+    title: "禁止著作權侵犯",
+    desc: "禁止上傳原文書、商業出版教材或任何標有版權聲明的掃描檔。",
+  },
 ];
 
 function GuidelinesSheet() {

--- a/containers/Dialogs/CreateThreadDialog.tsx
+++ b/containers/Dialogs/CreateThreadDialog.tsx
@@ -18,6 +18,14 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { Separator } from "@/components/ui/separator";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
 import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/components/ui/use-toast";
 import { createThreadSchema } from "@/schemas/thread";
@@ -29,9 +37,70 @@ import { useForm } from "react-hook-form";
 import { mutate } from "swr";
 import * as z from "zod";
 
+const GUIDELINES = [
+  {
+    title: "禁止人身攻擊",
+    desc: "不得對他人進行辱罵、嘲諷、人身攻擊或仇恨言論，請保持理性、友善的討論氛圍。",
+  },
+  {
+    title: "禁止不當圖片",
+    desc: "不得上傳色情、暴力、血腥或其他違反善良風俗之圖片或內容。",
+  },
+  {
+    title: "禁止廣告與垃圾訊息",
+    desc: "不得張貼商業廣告、詐騙連結或重複無意義的內容。",
+  },
+  {
+    title: "禁止侵犯隱私",
+    desc: "不得未經同意公開他人個人資訊，例如學號、姓名、聯絡方式等。",
+  },
+];
+
+function GuidelinesSheet() {
+  return (
+    <Sheet>
+      <SheetTrigger asChild>
+        <button
+          type="button"
+          className="text-primary underline underline-offset-2 hover:opacity-80"
+        >
+          社群規範
+        </button>
+      </SheetTrigger>
+      <SheetContent side="right" className="flex flex-col gap-0 overflow-y-auto p-0">
+        <SheetHeader className="px-6 py-5">
+          <SheetTitle className="text-lg">討論區社群規範</SheetTitle>
+          <p className="text-sm text-muted-foreground">
+            為維護良好的討論環境，請所有使用者遵守以下規範。
+            <br />
+            違規內容將被移除，情節嚴重者將停止使用資格。
+          </p>
+        </SheetHeader>
+        <Separator />
+        <ul className="flex flex-col divide-y px-6">
+          {GUIDELINES.map((g, i) => (
+            <li key={i} className="py-4">
+              <div className="mb-1 flex items-center gap-2">
+                <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-destructive/10 text-xs font-bold text-destructive">
+                  {i + 1}
+                </span>
+                <span className="font-medium">{g.title}</span>
+              </div>
+              <p className="pl-7 text-sm leading-relaxed text-muted-foreground">
+                {g.desc}
+              </p>
+            </li>
+          ))}
+        </ul>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
 const CreateThreadDialog = () => {
   const { toast } = useToast();
   const [isLoading, setIsLoading] = useState(false);
+  const [agreed, setAgreed] = useState(false);
   const params = useParams();
   const { get, removeParams } = useQueryState();
   const courseId = params.course_id as string | undefined;
@@ -48,6 +117,7 @@ const CreateThreadDialog = () => {
 
   function closeDialog() {
     form.reset();
+    setAgreed(false);
     removeParams("open_create_thread_dialog");
   }
 
@@ -151,6 +221,20 @@ const CreateThreadDialog = () => {
             />
           </form>
         </Form>
+        <div className="flex items-start gap-2 py-1">
+          <Checkbox
+            id="agree-guidelines"
+            checked={agreed}
+            onCheckedChange={(v) => setAgreed(Boolean(v))}
+          />
+          <label
+            htmlFor="agree-guidelines"
+            className="text-sm leading-snug text-muted-foreground"
+          >
+            我已閱讀並同意遵守{" "}
+            <GuidelinesSheet />
+          </label>
+        </div>
         <DialogFooter>
           <DialogClose asChild>
             <Button variant="outline" disabled={isLoading}>
@@ -158,6 +242,7 @@ const CreateThreadDialog = () => {
             </Button>
           </DialogClose>
           <Button
+            disabled={!agreed}
             onClick={form.handleSubmit(onSubmit, (e) => {
               toast({
                 title:


### PR DESCRIPTION
This pull request enhances the user experience and compliance process when creating a new discussion thread by introducing a clear community guidelines workflow. It adds a visible, accessible list of rules and requires users to explicitly agree to them before proceeding.

**Community Guidelines Integration:**

* Added a `GuidelinesSheet` component that displays a list of community guidelines in a sidebar sheet, making the rules easily accessible from the thread creation dialog.
* Introduced a checkbox labeled "我已閱讀並同意遵守 社群規範" that users must check to indicate agreement with the guidelines before submitting the form; the submit button is disabled until this is checked.
* Ensured that the agreement state resets when the dialog is closed, preventing accidental submission without renewed consent.

**UI and Dependency Updates:**

* Imported new UI components (`Sheet`, `SheetContent`, `SheetHeader`, `SheetTitle`, `SheetTrigger`, and `Separator`) to support the guidelines sheet functionality.