### PR TITLE
feat: add superuser can delete all thread and comment

### DIFF
--- a/components/thread/CommentItem.tsx
+++ b/components/thread/CommentItem.tsx
@@ -164,6 +164,7 @@ const ReplyItem = ({
   const { toast } = useToast();
   const { userData } = userStore();
   const isLoggedIn = !isEmpty(userData);
+  const isSuperUser = userData?.is_super_user;
   const [liked, setLiked] = useState(reply.liked ?? false);
   const [likeCount, setLikeCount] = useState(reply.like_count);
   const [isLiking, setIsLiking] = useState(false);
@@ -255,7 +256,7 @@ const ReplyItem = ({
               <Heart className="h-3.5 w-3.5" />
             </span>
           )}
-          {isOwner && (
+          {(isOwner || isSuperUser) && (
             <AlertDialog>
               <AlertDialogTrigger asChild>
                 <Button
@@ -331,6 +332,7 @@ const CommentItem = ({
   const { toast } = useToast();
   const { userData } = userStore();
   const isLoggedIn = !isEmpty(userData);
+  const isSuperUser = userData?.is_super_user;
   const [liked, setLiked] = useState(comment.liked ?? false);
   const [likeCount, setLikeCount] = useState(comment.like_count);
   const [isLiking, setIsLiking] = useState(false);
@@ -436,7 +438,7 @@ const CommentItem = ({
               <Heart className="h-4 w-4" />
             </span>
           )}
-          {isOwner && (
+          {(isOwner || isSuperUser) && (
             <AlertDialog>
               <AlertDialogTrigger asChild>
                 <Button

--- a/components/thread/ThreadCard.tsx
+++ b/components/thread/ThreadCard.tsx
@@ -50,6 +50,7 @@ const ThreadCard = ({ thread, courseId }: ThreadCardProps) => {
   const { toast } = useToast();
   const { userData } = userStore();
   const isLoggedIn = !isEmpty(userData);
+  const isSuperUser = userData?.is_super_user;
   const [liked, setLiked] = useState(thread.liked ?? false);
   const [likeCount, setLikeCount] = useState(thread.like_count);
   const [isLiking, setIsLiking] = useState(false);
@@ -125,7 +126,7 @@ const ThreadCard = ({ thread, courseId }: ThreadCardProps) => {
               匿名
             </Badge>
           )}
-          {thread.is_owner && (
+          {(thread.is_owner || isSuperUser) && (
             <div onClick={(e) => { e.stopPropagation(); e.preventDefault(); }}>
               <AlertDialog>
                 <AlertDialogTrigger asChild>


### PR DESCRIPTION
This pull request updates the permissions logic for deleting threads, comments, and replies to allow both the original owner and users with superuser privileges to perform delete actions. The changes are applied consistently across `ThreadCard`, `CommentItem`, and `ReplyItem` components.

**Permission logic improvements:**

* Added an `isSuperUser` check based on the `userData?.is_super_user` property in `ThreadCard`, `CommentItem`, and `ReplyItem` components to identify superusers. [[1]](diffhunk://#diff-13af614b19bfa728fd8e19cfc8cbeecb1e09774a47dccff4fe9de57f54c8ff82R53) [[2]](diffhunk://#diff-9e38b7864257206fe2f9eef3485919673e5085a410fd18e2f7b3b23c6204847cR167) [[3]](diffhunk://#diff-9e38b7864257206fe2f9eef3485919673e5085a410fd18e2f7b3b23c6204847cR335)
* Updated the delete button rendering logic to allow both owners and superusers to see and use the delete option for threads, comments, and replies. [[1]](diffhunk://#diff-13af614b19bfa728fd8e19cfc8cbeecb1e09774a47dccff4fe9de57f54c8ff82L128-R129) [[2]](diffhunk://#diff-9e38b7864257206fe2f9eef3485919673e5085a410fd18e2f7b3b23c6204847cL439-R441) [[3]](diffhunk://#diff-9e38b7864257206fe2f9eef3485919673e5085a410fd18e2f7b3b23c6204847cL258-R259)